### PR TITLE
Modification of yml to include bounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,19 +134,22 @@ parameters:
     default-value: DEFAULT_VALUE_A
     datatype: DATATYPE_A
     description: Description of Parameter A
-    parameter_bounds: # Boundaries for int and float datatype
+    parameter-bounds: # Boundaries for int and float datatype
       - 0 # Lower bound
       - inf # Upper bound
     options: null
+    allow-custom-value: false # If true the user can add a custom value out of parameter-bounds, or options
+
   - name: PARAMETER B
     default-value: DEFAULT_VALUE_B
     datatype: DATATYPE_B
     description: Description of Parameter B
-    parameter_bounds: null
+    parameter-bounds: null
     options: # If your string parameter is limited to a few option, please list them here. 
       - OptionA
       - OptionB
       - OptionC
+    allow-custom-value: false # If true the user can add a custom value out of parameter-bounds, or options
 
 # If applicable, data-input list required by the component
 data-inputs:

--- a/README.md
+++ b/README.md
@@ -134,10 +134,19 @@ parameters:
     default-value: DEFAULT_VALUE_A
     datatype: DATATYPE_A
     description: Description of Parameter A
+    parameter_bounds: # Boundaries for int and float datatype
+      - 0 # Lower bound
+      - inf # Upper bound
+    options: null
   - name: PARAMETER B
     default-value: DEFAULT_VALUE_B
     datatype: DATATYPE_B
     description: Description of Parameter B
+    parameter_bounds: null
+    options: # If your string parameter is limited to a few option, please list them here. 
+      - OptionA
+      - OptionB
+      - OptionC
 
 # If applicable, data-input list required by the component
 data-inputs:

--- a/odtp.yml
+++ b/odtp.yml
@@ -34,19 +34,21 @@ parameters:
     default-value: DEFAULT_VALUE_A
     datatype: DATATYPE_A
     description: Description of Parameter A
-    parameter_bounds: # Boundaries for int and float datatype
+    parameter-bounds: # Boundaries for int and float datatype
       - 0 # Lower bound
       - inf # Upper bound
     options: null
+    allow-custom-value: false # If true the user can add a custom value out of parameter-bounds, or options
   - name: PARAMETER B
     default-value: DEFAULT_VALUE_B
     datatype: DATATYPE_B
     description: Description of Parameter B
-    parameter_bounds: null
+    parameter-bounds: null
     options: # If your string parameter is limited to a few option, please list them here. 
       - OptionA
       - OptionB
       - OptionC
+    allow-custom-value: false # If true the user can add a custom value out of parameter-bounds, or options
 
 # If applicable, data-input list required by the component
 data-inputs:

--- a/odtp.yml
+++ b/odtp.yml
@@ -34,10 +34,19 @@ parameters:
     default-value: DEFAULT_VALUE_A
     datatype: DATATYPE_A
     description: Description of Parameter A
+    parameter_bounds: # Boundaries for int and float datatype
+      - 0 # Lower bound
+      - inf # Upper bound
+    options: null
   - name: PARAMETER B
     default-value: DEFAULT_VALUE_B
     datatype: DATATYPE_B
     description: Description of Parameter B
+    parameter_bounds: null
+    options: # If your string parameter is limited to a few option, please list them here. 
+      - OptionA
+      - OptionB
+      - OptionC
 
 # If applicable, data-input list required by the component
 data-inputs:


### PR DESCRIPTION
`odtp.yml` has been modified in order to accept parameters bounds and close list of options. 

This includes: 

- `parameter-bounds` for lower and upper limits. 
- `options` for list of predefined options
- `allow-custom-value` for accepting values outside the boundaries or options from the user. This is useful when giving some suggestions to the users, but no limiting the parameter value to these. 

```
parameters:
  - name: PARAMETER A
    default-value: DEFAULT_VALUE_A
    datatype: DATATYPE_A
    description: Description of Parameter A
    parameter-bounds: # Boundaries for int and float datatype
      - 0 # Lower bound
      - inf # Upper bound
    options: null
    allow-custom-value: false # If true the user can add a custom value out of parameter-bounds, or options
  - name: PARAMETER B
    default-value: DEFAULT_VALUE_B
    datatype: DATATYPE_B
    description: Description of Parameter B
    parameter-bounds: null
    options: # If your string parameter is limited to a few option, please list them here. 
      - OptionA
      - OptionB
      - OptionC
    allow-custom-value: false # If true the user can add a custom value out of parameter-bounds, or options
 ```